### PR TITLE
encoding: hex, percent, base64(rename)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ __pycache__
 
 #
 /test/**/*.xml
-/base64/**/*.xml
+/encoding/**/*.xml
 /mersenne_twister/**/*.xml
 /ringbuffer/**/*.xml
 /stats/**/*.xml

--- a/README.md
+++ b/README.md
@@ -67,9 +67,17 @@ JiecLibに含まれるライブラリと、IEC 61131-10 XMLを生成するため
     * [Array_mergesort_lreal](./array/sort.txt) / [Array_mergesort_dint](./array/sort.txt): マージソート
     * [Array_quicksort_lreal](./array/sort.txt) / [Array_quicksort_dint](./array/sort.txt): クイックソート
   * IEC 61131-10 XML生成コマンド: `jiecc ./array/array.txt -I. -I./vendor/jiecunit/sys -o ./array/array.xml -t omron`
-* [base64](./base64)
-  * メール等で使用されているエンコード方式Base64です。
-  * IEC 61131-10 XML生成コマンド: `jiecc ./base64/base64.txt -I. -I./vendor/jiecunit/sys -o ./base64/base64.xml -t omron`
+* [encoding](./encoding)
+  * エンコーディング関連ライブラリです。
+  * **Base64**
+    * [base64encode](./encoding/base64.txt) / [base64decode](./encoding/base64.txt)
+    * IEC 61131-10 XML生成コマンド: `jiecc ./encoding/base64.txt -I. -I./vendor/jiecunit/sys -o ./encoding/base64.xml -t omron`
+  * **Percent（URLエンコード）**
+    * [percentencode](./encoding/percent.txt) / [percentdecode](./encoding/percent.txt)
+    * IEC 61131-10 XML生成コマンド: `jiecc ./encoding/percent.txt -I. -I./vendor/jiecunit/sys -o ./encoding/percent.xml -t omron`
+  * **Hex**
+    * [hexencode](./encoding/hex.txt) / [hexdecode](./encoding/hex.txt)
+    * IEC 61131-10 XML生成コマンド: `jiecc ./encoding/hex.txt -I. -I./vendor/jiecunit/sys -o ./encoding/hex.xml -t omron`
 * [math](./math)
   * 数学関数ライブラリです。
   * [Math_floor](./math/floor.txt): 床関数（floor）

--- a/encoding/base64.txt
+++ b/encoding/base64.txt
@@ -1,16 +1,23 @@
 (*
  * $ cd <JiecLib Project Root>
- * $ jiecc ./base64/base64.txt -I. -I./vendor/jiecunit/sys -o ./base64/base64.xml -t omron
+ * $ jiecc ./encoding/base64.txt -I. -I./vendor/jiecunit/sys -o ./encoding/base64.xml -t omron
  *)
-{#ifndef __BASE_64_TXT__}
-{#define __BASE_64_TXT__}
+{#ifndef __ENCODING_BASE64_TXT__}
+{#define __ENCODING_BASE64_TXT__}
 
 {#include <sys.txt>}
 {#include <string_lib/string_lib.txt>}
 
-{#define CHAR_MAX_BYTE 4}
 {#define STRING string[STRING_MAX_SIZE]}
 
+(*{doc バイト配列をBase64文字列へエンコードする。
+@in_out dat 入力バイト配列。
+@input offset datの開始オフセット。
+	デフォルト値: 0
+@input length エンコード対象の要素数。
+	-1を指定するとき、offsetから末尾までを対象とする。
+	デフォルト値: -1
+@error offset/lengthが配列範囲外を指す場合。}*)
 function base64encode: STRING
 	_PROLOGUE_OF_FUNCTION_()
 	var_in_out
@@ -95,19 +102,22 @@ function base64encode: STRING
 	{end}
 end
 
-(**
- * @return number of data size.
- *)
+(*{doc Base64文字列をデコードし、バイト配列へ格納する。
+@input txt 入力Base64文字列。
+@in_out dat デコード結果を書き込む配列。
+@input offset datへの書き込み開始オフセット。
+  デフォルト値: 0
+@return datへ格納したバイト数。}*)
 function base64decode: dint
 	_PROLOGUE_OF_FUNCTION_()
 	var_input
 		txt: STRING (*{doc: input base64 text.}*);
 	end
-	var_input
-		offset: dint := 0;
-	end
 	var_in_out
 		dat: array[*] of byte;
+	end
+	var_input
+		offset: dint := 0;
 	end
 	var_temp
 		C2B: array[128] of byte constant := [
@@ -126,23 +136,23 @@ function base64decode: dint
 	end
 	{st}
 	l := len(txt);
-	p := 1;
+	p := 0;
 	o := offset;
-	while p <= l do
+	while p < l do
 		// b1
 		repeat
-			b1 := C2B[asciiCharCodeAt(txt, p)];
+			b1 := C2B[String_asciiCharCodeAt(txt, p)];
 			p := p + 1;
-			until (p > l) or (b1 <> byte#255)
+			until (p >= l) or (b1 <> byte#255)
 		end_repeat;
 		if b1 = byte#255 then
 			exit;
 		end_if;
 		// b2
 		repeat
-			b2 := C2B[asciiCharCodeAt(txt, p)];
+			b2 := C2B[String_asciiCharCodeAt(txt, p)];
 			p := p + 1;
-			until (p > l) or (b2 <> byte#255)
+			until (p >= l) or (b2 <> byte#255)
 		end_repeat;
 		if b2 = byte#255 then
 			exit;
@@ -151,14 +161,14 @@ function base64decode: dint
 		o := o + 1;
 		// b3
 		repeat
-			b3 := dint_to_byte(asciiCharCodeAt(txt, p));
+			b3 := dint_to_byte(String_asciiCharCodeAt(txt, p));
 			p := p + 1;
 			if b3 = byte#61 then
 				base64decode := o - offset;
 				return;
 			end_if;
 			b3 := C2B[byte_to_usint(b3)];
-			until (p > l) or (b3 <> byte#255)
+			until (p >= l) or (b3 <> byte#255)
 		end_repeat;
 		if b3 = byte#255 then
 			exit;
@@ -167,14 +177,14 @@ function base64decode: dint
 		o := o + 1;
 		// b4
 		repeat
-			b4 := dint_to_byte(asciiCharCodeAt(txt, p));
+			b4 := dint_to_byte(String_asciiCharCodeAt(txt, p));
 			p := p + 1;
 			if b4 = byte#61 then
 				base64decode := o - offset;
 				return;
 			end_if;
 			b4 := C2B[byte_to_usint(b4)];
-			until (p > l) or (b4 <> byte#255)
+			until (p >= l) or (b4 <> byte#255)
 		end_repeat;
 		if b4 = byte#255 then
 			exit;

--- a/encoding/hex.txt
+++ b/encoding/hex.txt
@@ -1,0 +1,167 @@
+(*
+ * $ cd <JiecLib Project Root>
+ * $ jiecc ./encoding/hex.txt -I. -I./vendor/jiecunit/sys -o ./encoding/hex.xml -t omron
+ *)
+{#ifndef __ENCODING_HEX_TXT__}
+{#define __ENCODING_HEX_TXT__}
+
+{#include <sys.txt>}
+{#include <string_lib/string_lib.txt>}
+
+{#define STRING string[STRING_MAX_SIZE]}
+{#define CODE_0 48}
+{#define CODE_9 57}
+{#define CODE_A 65}
+{#define CODE_F 70}
+{#define CODE_a 97}
+{#define CODE_f 102}
+
+(*{doc 16進文字の1桁を数値へ変換する。
+@input code ASCIIコード。
+@return 0..15の値。16進文字でない場合、-1。}*)
+function hex_nibble: dint
+	_PROLOGUE_OF_FUNCTION_()
+	var_input
+		code: dint;
+	end
+	{st}
+	if (code >= CODE_0) and (code <= CODE_9) then
+		hex_nibble := code - CODE_0;
+		return;
+	end_if;
+	if (code >= CODE_A) and (code <= CODE_F) then
+		hex_nibble := code - CODE_A + 10;
+		return;
+	end_if;
+	if (code >= CODE_a) and (code <= CODE_f) then
+		hex_nibble := code - CODE_a + 10;
+		return;
+	end_if;
+	hex_nibble := -1;
+	{end}
+end
+
+(*{doc バイト配列を16進文字列へエンコードする。
+@in_out dat 入力バイト配列。
+@input offset datの開始オフセット。
+  デフォルト値: 0
+@input length エンコード対象の要素数。
+  -1を指定するとき、offsetから末尾までを対象とする。
+  デフォルト値: -1
+@return 16進文字列（大文字）。
+@error offset/lengthが配列範囲外を指す場合。}*)
+function hexencode: STRING
+	_PROLOGUE_OF_FUNCTION_()
+	var_in_out
+		dat: array[*] of byte;
+	end
+	var_input
+		offset: dint := 0;
+		length: dint := -1;
+	end
+	var_temp
+		HEX: array[0..15] of string[1 + 1] constant := [
+			'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F'
+		];
+		i0, i1, i: dint;
+		startindex, endindex: dint;
+		b: byte;
+		hi, lo: dint;
+		out: STRING;
+	end
+	{st}
+	out := '';
+	i0 := lower_bound(dat, 1);
+	i1 := upper_bound(dat, 1);
+	startindex := i0 + offset;
+	if length = -1 then
+		endindex := i1;
+	else
+		endindex := startindex + length - 1;
+	end_if;
+	if (startindex < i0) or (endindex < startindex) or (endindex > i1) then
+		eno := false;
+		return;
+	end_if;
+
+	for i := startindex to endindex by 1 do
+		b := dat[i];
+		hi := byte_to_dint(shr(b, 4));
+		lo := byte_to_dint(b and byte#16#0F);
+		out := concat(out, HEX[hi]);
+		out := concat(out, HEX[lo]);
+	end_for;
+
+	hexencode := out;
+	{end}
+end
+
+(*{doc 16進文字列をデコードし、バイト配列へ格納する。
+@input txt 入力16進文字列。
+@in_out dat デコード結果を書き込む配列。
+@input offset datへの書き込み開始オフセット。
+  デフォルト値: 0
+@return datへ格納したバイト数。
+@error 文字列長が奇数、16進文字が不正、またはdat範囲外へ書き込む場合。}*)
+function hexdecode: dint
+	_PROLOGUE_OF_FUNCTION_()
+	var_input
+		txt: STRING;
+	end
+	var_in_out
+		dat: array[*] of byte;
+	end
+	var_input
+		offset: dint := 0;
+	end
+	var_temp
+		l, i: dint;
+		i0, i1: dint;
+		need_count: dint;
+		o: dint;
+		h1, h2: dint;
+		c1, c2: dint;
+	end
+	{st}
+	l := uint_to_dint(len(txt));
+	if (l mod 2) <> 0 then
+		eno := false;
+		return;
+	end_if;
+
+	need_count := l / 2;
+	i0 := lower_bound(dat, 1);
+	i1 := upper_bound(dat, 1);
+	if (offset < 0) or ((i0 + offset + need_count - 1) > i1) then
+		eno := false;
+		return;
+	end_if;
+
+	o := i0 + offset;
+	i := 0;
+	while i < l do
+		c1 := String_asciiCharCodeAt(txt, i);
+		c2 := String_asciiCharCodeAt(txt, i + 1);
+		h1 := hex_nibble(c1);
+		h2 := hex_nibble(c2);
+		if (h1 < 0) or (h2 < 0) then
+			eno := false;
+			return;
+		end_if;
+		dat[o] := shl(dint_to_byte(h1), 4) or dint_to_byte(h2);
+		o := o + 1;
+		i := i + 2;
+	end_while;
+
+	hexdecode := need_count;
+	{end}
+end
+
+{#undef CODE_0}
+{#undef CODE_9}
+{#undef CODE_A}
+{#undef CODE_F}
+{#undef CODE_a}
+{#undef CODE_f}
+
+{#endif}

--- a/encoding/percent.txt
+++ b/encoding/percent.txt
@@ -1,0 +1,150 @@
+(*
+ * $ cd <JiecLib Project Root>
+ * $ jiecc ./encoding/percent.txt -I. -I./vendor/jiecunit/sys -o ./encoding/percent.xml -t omron
+ *)
+{#ifndef __ENCODING_PERCENT_TXT__}
+{#define __ENCODING_PERCENT_TXT__}
+
+{#include <sys.txt>}
+{#include <string_lib/string_lib.txt>}
+
+{#define STRING string[STRING_MAX_SIZE]}
+
+{#define CODE_0 48}
+{#define CODE_9 57}
+{#define CODE_A 65}
+{#define CODE_F 70}
+{#define CODE_Z 90}
+{#define CODE_a 97}
+{#define CODE_f 102}
+{#define CODE_z 122}
+
+(*{doc 16進文字の1桁を数値へ変換する。
+@input code ASCIIコード。
+@return 0..15の値。16進文字でない場合、-1。}*)
+function percent_hex_nibble: dint
+	_PROLOGUE_OF_FUNCTION_()
+	var_input
+		code: dint;
+	end
+	{st}
+	if (code >= CODE_0) and (code <= CODE_9) then
+		percent_hex_nibble := code - CODE_0;
+		return;
+	end_if;
+	if (code >= CODE_A) and (code <= CODE_F) then
+		percent_hex_nibble := code - CODE_A + 10;
+		return;
+	end_if;
+	if (code >= CODE_a) and (code <= CODE_f) then
+		percent_hex_nibble := code - CODE_a + 10;
+		return;
+	end_if;
+	percent_hex_nibble := -1;
+	{end}
+end
+
+(*{doc 文字列をパーセントエンコード（URLエンコード）する。
+@input txt 入力文字列。
+@return エンコード後文字列。
+@error 入力文字のASCIIコード取得に失敗した場合。}*)
+function percentencode: STRING
+	_PROLOGUE_OF_FUNCTION_()
+	var_input
+		txt: STRING;
+	end
+	var_temp
+		HEX: array[0..15] of string[1 + 1] constant := [
+			'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F'
+		];
+		i, l, code: dint;
+		hi, lo: dint;
+		out: STRING;
+	end
+	{st}
+	out := '';
+	l := uint_to_dint(len(txt));
+	for i := 0 to l - 1 by 1 do
+		code := String_asciiCharCodeAt(txt, i);
+		if code < 0 then
+			eno := false;
+			return;
+		end_if;
+
+		if ((code >= CODE_0) and (code <= CODE_9)) or ((code >= CODE_A) and (code <= CODE_Z)) or ((code >= CODE_a) and (code <= CODE_z)) or (code = 45) or (code = 46) or (code = 95) or (code = 126) then
+			out := concat(out, String_fromAsciiCharCode1(code));
+		else
+			hi := byte_to_dint(shr(dint_to_byte(code), 4));
+			lo := byte_to_dint(dint_to_byte(code) and byte#16#0F);
+			out := concat(out, '%');
+			out := concat(out, HEX[hi]);
+			out := concat(out, HEX[lo]);
+		end_if;
+	end_for;
+	percentencode := out;
+	{end}
+end
+
+(*{doc パーセントエンコード文字列をデコードする。
+@input txt 入力文字列。
+@return デコード後文字列。
+@error %に続く2桁の16進数が不正な場合、またはASCIIコード取得に失敗した場合。}*)
+function percentdecode: STRING
+	_PROLOGUE_OF_FUNCTION_()
+	var_input
+		txt: STRING;
+	end
+	var_temp
+		i, l, code: dint;
+		h1, h2: dint;
+		decoded_code: dint;
+		out: STRING;
+	end
+	{st}
+	out := '';
+	l := uint_to_dint(len(txt));
+	i := 0;
+	while i < l do
+		code := String_asciiCharCodeAt(txt, i);
+		if code < 0 then
+			eno := false;
+			return;
+		end_if;
+
+		if code = 37 then
+			if i + 2 >= l then
+				eno := false;
+				return;
+			end_if;
+			h1 := percent_hex_nibble(String_asciiCharCodeAt(txt, i + 1));
+			h2 := percent_hex_nibble(String_asciiCharCodeAt(txt, i + 2));
+			if (h1 < 0) or (h2 < 0) then
+				eno := false;
+				return;
+			end_if;
+			decoded_code := h1 * 16 + h2;
+			if decoded_code > 127 then
+				eno := false;
+				return;
+			end_if;
+			out := concat(out, String_fromAsciiCharCode1(decoded_code));
+			i := i + 3;
+		else
+			out := concat(out, String_fromAsciiCharCode1(code));
+			i := i + 1;
+		end_if;
+	end_while;
+	percentdecode := out;
+	{end}
+end
+
+{#undef CODE_0}
+{#undef CODE_9}
+{#undef CODE_A}
+{#undef CODE_F}
+{#undef CODE_Z}
+{#undef CODE_a}
+{#undef CODE_f}
+{#undef CODE_z}
+
+{#endif}

--- a/test/encoding/test_base64.txt
+++ b/test/encoding/test_base64.txt
@@ -1,16 +1,19 @@
 (*
  * $ cd <JiecLib Project Root>
- * $ jiecc ./test/base64/test_base64.txt -I. -I./vendor/jiecunit -I./vendor/jiecunit/sys -o ./test/base64/test_base64.xml -t omron
+ * $ jiecc ./test/encoding/test_base64.txt -I. -I./vendor/jiecunit -I./vendor/jiecunit/sys -D_TEST_ -o ./test/encoding/test_base64.xml -t omron
  *)
 {#include <jiecunit.txt>}
-{#include <base64/base64.txt>}
 
+{#include <encoding/base64.txt>}
+
+{#ifdef _TEST_}
 DEFINE_CONFIGURATION(
 	_JIEC_TESTNAMES_LIST_(
 		'test_base64encode',
 		'test_base64decode'
 	)
 )
+{#endif}
 
 TEST_S(test_base64encode)
 	var
@@ -75,15 +78,18 @@ END_TEST_S
 
 TEST_S(test_base64decode)
 	var
+		l: dint;
 		x_4096: array[4096] of byte;
 	end
 	{st}
 	//
-	EXPECT_EQ_INT32(2, base64decode(txt:='XYZ=', dat:=x_4096));
+	l := base64decode(txt:='XYZ=', dat:=x_4096);
+	EXPECT_EQ_INT32(2, l);
 	EXPECT_EQ_BYTE(byte#16#5d, x_4096[0]);
 	EXPECT_EQ_BYTE(byte#16#86, x_4096[1]);
 	//
-	EXPECT_EQ_INT32(8, base64decode(txt:='AgMFBwsNERc=', dat:=x_4096));
+	l := base64decode(txt:='AgMFBwsNERc=', dat:=x_4096);
+	EXPECT_EQ_INT32(8, l);
 	EXPECT_EQ_BYTE(byte#16#02, x_4096[0]);
 	EXPECT_EQ_BYTE(byte#16#03, x_4096[1]);
 	EXPECT_EQ_BYTE(byte#16#05, x_4096[2]);
@@ -93,55 +99,65 @@ TEST_S(test_base64decode)
 	EXPECT_EQ_BYTE(byte#16#11, x_4096[6]);
 	EXPECT_EQ_BYTE(byte#16#17, x_4096[7]);
 	//
-	EXPECT_EQ_INT32(1, base64decode(txt:='AA==', dat:=x_4096));
+	l := base64decode(txt:='AA==', dat:=x_4096);
+	EXPECT_EQ_INT32(1, l);
 	EXPECT_EQ_BYTE(byte#16#00, x_4096[0]);
 	//
-	EXPECT_EQ_INT32(2, base64decode(txt:='AAA=', dat:=x_4096));
+	l := base64decode(txt:='AAA=', dat:=x_4096);
+	EXPECT_EQ_INT32(2, l);
 	EXPECT_EQ_BYTE(byte#16#00, x_4096[0]);
 	EXPECT_EQ_BYTE(byte#16#00, x_4096[1]);
 	//
-	EXPECT_EQ_INT32(3, base64decode(txt:='AAAA', dat:=x_4096));
+	l := base64decode(txt:='AAAA', dat:=x_4096);
+	EXPECT_EQ_INT32(3, l);
 	EXPECT_EQ_BYTE(byte#16#00, x_4096[0]);
 	EXPECT_EQ_BYTE(byte#16#00, x_4096[1]);
 	EXPECT_EQ_BYTE(byte#16#00, x_4096[2]);
 	//
-	EXPECT_EQ_INT32(3, base64decode(txt:='AQID', dat:=x_4096));
+	l := base64decode(txt:='AQID', dat:=x_4096);
+	EXPECT_EQ_INT32(3, l);
 	EXPECT_EQ_BYTE(byte#16#01, x_4096[0]);
 	EXPECT_EQ_BYTE(byte#16#02, x_4096[1]);
 	EXPECT_EQ_BYTE(byte#16#03, x_4096[2]);
 	//
-	EXPECT_EQ_INT32(5, base64decode(txt:='AgMFBws=', dat:=x_4096));
+	l := base64decode(txt:='AgMFBws=', dat:=x_4096);
+	EXPECT_EQ_INT32(5, l);
 	EXPECT_EQ_BYTE(byte#16#02, x_4096[0]);
 	EXPECT_EQ_BYTE(byte#16#03, x_4096[1]);
 	EXPECT_EQ_BYTE(byte#16#05, x_4096[2]);
 	EXPECT_EQ_BYTE(byte#16#07, x_4096[3]);
 	EXPECT_EQ_BYTE(byte#16#0b, x_4096[4]);
 	//
-	EXPECT_EQ_INT32(3, base64decode(txt:='q83v', dat:=x_4096));
+	l := base64decode(txt:='q83v', dat:=x_4096);
+	EXPECT_EQ_INT32(3, l);
 	EXPECT_EQ_BYTE(byte#16#ab, x_4096[0]);
 	EXPECT_EQ_BYTE(byte#16#cd, x_4096[1]);
 	EXPECT_EQ_BYTE(byte#16#ef, x_4096[2]);
 	//
-	EXPECT_EQ_INT32(4, base64decode(txt:='3q2+7w==', dat:=x_4096));
+	l := base64decode(txt:='3q2+7w==', dat:=x_4096);
+	EXPECT_EQ_INT32(4, l);
 	EXPECT_EQ_BYTE(byte#16#de, x_4096[0]);
 	EXPECT_EQ_BYTE(byte#16#ad, x_4096[1]);
 	EXPECT_EQ_BYTE(byte#16#be, x_4096[2]);
 	EXPECT_EQ_BYTE(byte#16#ef, x_4096[3]);
 	//
-	EXPECT_EQ_INT32(4, base64decode(txt:='fwAB/w==', dat:=x_4096));
+	l := base64decode(txt:='fwAB/w==', dat:=x_4096);
+	EXPECT_EQ_INT32(4, l);
 	EXPECT_EQ_BYTE(byte#16#7f, x_4096[0]);
 	EXPECT_EQ_BYTE(byte#16#00, x_4096[1]);
 	EXPECT_EQ_BYTE(byte#16#01, x_4096[2]);
 	EXPECT_EQ_BYTE(byte#16#ff, x_4096[3]);
 	//
-	EXPECT_EQ_INT32(5, base64decode(txt:='SGVsbG8=', dat:=x_4096)); // Hello
+	l := base64decode(txt:='SGVsbG8=', dat:=x_4096); // Hello
+	EXPECT_EQ_INT32(5, l);
 	EXPECT_EQ_BYTE(byte#16#48, x_4096[0]);
 	EXPECT_EQ_BYTE(byte#16#65, x_4096[1]);
 	EXPECT_EQ_BYTE(byte#16#6c, x_4096[2]);
 	EXPECT_EQ_BYTE(byte#16#6c, x_4096[3]);
 	EXPECT_EQ_BYTE(byte#16#6f, x_4096[4]);
 	//
-	EXPECT_EQ_INT32(8, base64decode(txt:='U29mdHdhcmU=', dat:=x_4096));
+	l := base64decode(txt:='U29mdHdhcmU=', dat:=x_4096);
+	EXPECT_EQ_INT32(8, l);
 	EXPECT_EQ_BYTE(byte#16#53, x_4096[0]);
 	EXPECT_EQ_BYTE(byte#16#6f, x_4096[1]);
 	EXPECT_EQ_BYTE(byte#16#66, x_4096[2]);
@@ -151,7 +167,8 @@ TEST_S(test_base64decode)
 	EXPECT_EQ_BYTE(byte#16#72, x_4096[6]);
 	EXPECT_EQ_BYTE(byte#16#65, x_4096[7]);
 	//
-	EXPECT_EQ_INT32(48, base64decode(txt:='ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/', dat:=x_4096));
+	l := base64decode(txt:='ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/', dat:=x_4096);
+	EXPECT_EQ_INT32(48, l);
 	EXPECT_EQ_BYTE(byte#16#00, x_4096[0]);
 	EXPECT_EQ_BYTE(byte#16#10, x_4096[1]);
 	EXPECT_EQ_BYTE(byte#16#83, x_4096[2]);

--- a/test/encoding/test_encoding.txt
+++ b/test/encoding/test_encoding.txt
@@ -1,0 +1,35 @@
+(*
+ * $ cd <JiecLib Project Root>
+ * $ jiecc ./test/encoding/test_encoding.txt -I. -I./vendor/jiecunit/sys -I./vendor/jiecunit -D_TEST_ -o ./test/encoding/test_encoding.xml -t omron
+ *)
+{#if _JIECC and (_JIECC_VER < 514)}
+	{#error This test requires Jiecc 5.14 or later.}
+{#endif}
+{#include <jiecunit.txt>}
+{#if _JIECUNIT and (_JIECUNIT_VER < 210)}
+	{#error This test requires JiecUnit 2.10 or later.}
+{#endif}
+
+{#include <encoding/base64.txt>}
+{#include <encoding/percent.txt>}
+{#include <encoding/hex.txt>}
+
+{#ifdef _TEST_}
+DEFINE_CONFIGURATION(
+	_JIEC_TESTNAMES_LIST_(
+		'test_base64encode',
+		'test_base64decode',
+		'test_percentencode',
+		'test_percentdecode',
+		'test_hexencode',
+		'test_hexdecode'
+	)
+)
+{#undef _TEST_}
+{#endif}
+
+{#include "test_base64.txt"}
+{#include "test_percent.txt"}
+{#include "test_hex.txt"}
+
+{#undef _TEST_}

--- a/test/encoding/test_hex.txt
+++ b/test/encoding/test_hex.txt
@@ -1,0 +1,80 @@
+(*
+ * $ cd <JiecLib Project Root>
+ * $ jiecc ./test/encoding/test_hex.txt -I. -I./vendor/jiecunit -I./vendor/jiecunit/sys -D_TEST_ -o ./test/encoding/test_hex.xml -t omron
+ *)
+{#include <jiecunit.txt>}
+
+{#include <encoding/hex.txt>}
+
+{#ifdef _TEST_}
+DEFINE_CONFIGURATION(
+	_JIEC_TESTNAMES_LIST_(
+		'test_hexencode',
+		'test_hexdecode'
+	)
+)
+{#endif}
+
+TEST_S(test_hexencode)
+	var
+		d1: array[0..4] of byte := [byte#16#00, byte#16#01, byte#16#2A, byte#16#FF, byte#16#B3];
+		o: bool;
+		r: STRING;
+	end
+	{st}
+	r := hexencode(dat:=d1, eno=>o);
+	EXPECT_TRUE(o);
+	EXPECT_EQ_STRING('00012AFFB3', r);
+
+	r := hexencode(dat:=d1, offset:=1, length:=3, eno=>o);
+	EXPECT_TRUE(o);
+	EXPECT_EQ_STRING('012AFF', r);
+
+	r := hexencode(dat:=d1, offset:=4, length:=1, eno=>o);
+	EXPECT_TRUE(o);
+	EXPECT_EQ_STRING('B3', r);
+
+	r := hexencode(dat:=d1, offset:=5, length:=1, eno=>o);
+	EXPECT_FALSE(o);
+
+	r := hexencode(dat:=d1, offset:=0, length:=0, eno=>o);
+	EXPECT_FALSE(o);
+	{end}
+END_TEST_S
+
+TEST_S(test_hexdecode)
+	var
+		d: array[0..7] of byte;
+		n: dint;
+		o: bool;
+	end
+	{st}
+	n := hexdecode(txt:='00012AFFB3', dat:=d);
+	EXPECT_EQ_INT32(5, n);
+	EXPECT_EQ_BYTE(byte#16#00, d[0]);
+	EXPECT_EQ_BYTE(byte#16#01, d[1]);
+	EXPECT_EQ_BYTE(byte#16#2A, d[2]);
+	EXPECT_EQ_BYTE(byte#16#FF, d[3]);
+	EXPECT_EQ_BYTE(byte#16#B3, d[4]);
+
+	n := hexdecode(txt:='0a0b0C0d', dat:=d);
+	EXPECT_EQ_INT32(4, n);
+	EXPECT_EQ_BYTE(byte#16#0A, d[0]);
+	EXPECT_EQ_BYTE(byte#16#0B, d[1]);
+	EXPECT_EQ_BYTE(byte#16#0C, d[2]);
+	EXPECT_EQ_BYTE(byte#16#0D, d[3]);
+
+	n := hexdecode(txt:='A1', offset:=2, dat:=d);
+	EXPECT_EQ_INT32(1, n);
+	EXPECT_EQ_BYTE(byte#16#A1, d[2]);
+
+	hexdecode(txt:='ABC', dat:=d, eno=>o);
+	EXPECT_FALSE(o);
+	hexdecode(txt:='ZZ', dat:=d, eno=>o);
+	EXPECT_FALSE(o);
+	hexdecode(txt:='0G', dat:=d, eno=>o);
+	EXPECT_FALSE(o);
+	hexdecode(txt:='001122334455667788', dat:=d, eno=>o);
+	EXPECT_FALSE(o);
+	{end}
+END_TEST_S

--- a/test/encoding/test_percent.txt
+++ b/test/encoding/test_percent.txt
@@ -1,0 +1,106 @@
+(*
+ * $ cd <JiecLib Project Root>
+ * $ jiecc ./test/encoding/test_percent.txt -I. -I./vendor/jiecunit -I./vendor/jiecunit/sys -D_TEST_ -o ./test/encoding/test_percent.xml -t omron
+ *)
+{#include <jiecunit.txt>}
+
+{#include <encoding/percent.txt>}
+
+{#ifdef _TEST_}
+DEFINE_CONFIGURATION(
+	_JIEC_TESTNAMES_LIST_(
+		'test_percentencode',
+		'test_percentdecode'
+	)
+)
+{#endif}
+
+TEST_S(test_percentencode)
+	var
+		r: STRING;
+		o: bool;
+	end
+	{st}
+	r := percentencode(txt:='');
+	EXPECT_EQ_STRING('', r);
+	r := percentencode(txt:='abcXYZ012');
+	EXPECT_EQ_STRING('abcXYZ012', r);
+	r := percentencode(txt:='a-b.c_d~');
+	EXPECT_EQ_STRING('a-b.c_d~', r);
+	r := percentencode(txt:='hello world');
+	EXPECT_EQ_STRING('hello%20world', r);
+	r := percentencode(txt:='A+B=C');
+	EXPECT_EQ_STRING('A%2BB%3DC', r);
+	r := percentencode(txt:='100%');
+	EXPECT_EQ_STRING('100%25', r);
+	r := percentencode(txt:='/path?x=1&y=2');
+	EXPECT_EQ_STRING('%2Fpath%3Fx%3D1%26y%3D2', r);
+	r := percentencode(txt:='"quoted"');
+	EXPECT_EQ_STRING('%22quoted%22', r);
+	r := percentencode(txt:='#$$&+,/:;=?@');
+	EXPECT_EQ_STRING('%23%24%26%2B%2C%2F%3A%3B%3D%3F%40', r);
+	r := percentencode(txt:='[]{}<>');
+	EXPECT_EQ_STRING('%5B%5D%7B%7D%3C%3E', r);
+	// control characters
+	r := percentencode(txt:='A$09B');
+	EXPECT_EQ_STRING('A%09B', r);
+	r := percentencode(txt:='$09$0A');
+	EXPECT_EQ_STRING('%09%0A', r);
+	// multi-byte (UTF-8 bytes)
+	percentencode(txt:='$E3$81$82', eno=>o);
+	EXPECT_FALSE(o);
+	{end}
+END_TEST_S
+
+TEST_S(test_percentdecode)
+	var
+		t: STRING;
+		o: bool;
+	end
+	{st}
+	t := percentdecode(txt:='', eno=>o);
+	EXPECT_TRUE(o);
+	EXPECT_EQ_STRING('', t);
+	// normal cases
+	t := percentdecode(txt:='abcXYZ012');
+	EXPECT_EQ_STRING('abcXYZ012', t);
+	t := percentdecode(txt:='hello%20world');
+	EXPECT_EQ_STRING('hello world', t);
+	t := percentdecode(txt:='A%2BB%3DC');
+	EXPECT_EQ_STRING('A+B=C', t);
+	t := percentdecode(txt:='100%25');
+	EXPECT_EQ_STRING('100%', t);
+	t := percentdecode(txt:='%2Fpath%3Fx%3D1%26y%3D2');
+	EXPECT_EQ_STRING('/path?x=1&y=2', t);
+	t := percentdecode(txt:='%22quoted%22');
+	EXPECT_EQ_STRING('"quoted"', t);
+	t := percentdecode(txt:='%23%24%26%2B%2C%2F%3A%3B%3D%3F%40');
+	EXPECT_EQ_STRING('#$$&+,/:;=?@', t);
+	t := percentdecode(txt:='%5b%5d%7b%7d%3c%3e');
+	EXPECT_EQ_STRING('[]{}<>', t);
+	// control characters
+	t := percentdecode(txt:='A%09B', eno=>o);
+	EXPECT_TRUE(o);
+	EXPECT_EQ_STRING('A$09B', t);
+	t := percentdecode(txt:='%09%0A', eno=>o);
+	EXPECT_TRUE(o);
+	EXPECT_EQ_STRING('$09$0A', t);
+	// multi-byte (UTF-8 bytes)
+	percentdecode(txt:='%E3%81%82', eno=>o);
+	EXPECT_FALSE(o);
+	// error cases
+	percentdecode(txt:='%', eno=>o);
+	EXPECT_FALSE(o);
+	percentdecode(txt:='%2', eno=>o);
+	EXPECT_FALSE(o);
+	percentdecode(txt:='%GG', eno=>o);
+	EXPECT_FALSE(o);
+	percentdecode(txt:='abc%4Z', eno=>o);
+	EXPECT_FALSE(o);
+	// mixed invalid patterns
+	percentdecode(txt:='abc%20def%4Zghi', eno=>o);
+	EXPECT_FALSE(o);
+	percentdecode(txt:='ok%2Fng%', eno=>o);
+	EXPECT_FALSE(o);
+	{end}
+END_TEST_S


### PR DESCRIPTION
以下のエンコーディング関連ライブラリを追加。base64はファイル移動のみ。

* [encoding](./encoding)
  * エンコーディング関連ライブラリです。
  * **Base64**
    * [base64encode](./encoding/base64.txt) / [base64decode](./encoding/base64.txt)
    * IEC 61131-10 XML生成コマンド: `jiecc ./encoding/base64.txt -I. -I./vendor/jiecunit/sys -o ./encoding/base64.xml -t omron`
  * **Percent（URLエンコード）**
    * [percentencode](./encoding/percent.txt) / [percentdecode](./encoding/percent.txt)
    * IEC 61131-10 XML生成コマンド: `jiecc ./encoding/percent.txt -I. -I./vendor/jiecunit/sys -o ./encoding/percent.xml -t omron`
  * **Hex**
    * [hexencode](./encoding/hex.txt) / [hexdecode](./encoding/hex.txt)
    * IEC 61131-10 XML生成コマンド: `jiecc ./encoding/hex.txt -I. -I./vendor/jiecunit/sys -o ./encoding/hex.xml -t omron`
    * 