### PR TITLE
Fix String_lastIndexOf and update README test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,7 +666,7 @@ $ git submodule update --remote
 
 ```
 $ cd jieclib
-$ jiecc ./test/string_lib/test_string_lib.txt -I./src -I./vendor/jiecunit -o ./test/string_lib/test_string_lib.xml -t omron
+$ jiecc ./test/string_lib/test_string_lib.txt -I./src -I./vendor/jiecunit -D_TEST_ -o ./test/string_lib/test_string_lib.xml -t omron
 ```
 
 `./test/string_lib/test_string_lib.xml` が生成されます。

--- a/src/string_lib/string_lib.txt
+++ b/src/string_lib/string_lib.txt
@@ -387,32 +387,24 @@ function String_lastIndexOf: dint
 		segment: STRING;
 	end
 	{st}
-	// empty needle: 既定は末尾、position指定時はその値
 	l := len(self);
 	m := len(searchString);
-	if m = 0 then
-		if position = __DINT_MAX__ then
-			String_lastIndexOf := l;
-		else
-			String_lastIndexOf := position;
+	if m <> 0 then
+		start_pos := min(position, l - m);
+		if start_pos >= 0 then
+			// right to left search
+			for i := start_pos to 0 by -1 do
+				segment := mid(self, dint_to_uint(m), dint_to_uint(i + 1));
+				if segment = searchString then
+					String_lastIndexOf := i;
+					return;
+				end_if;
+			end_for;
 		end_if;
-		return;
-	end_if;
-	// 探索開始位置を決定（末尾側から）
-	start_pos := min(position, l - m);
-	if start_pos < 0 then
 		String_lastIndexOf := -1;
-		return;
+	else
+		String_lastIndexOf := min(position, l);
 	end_if;
-	// 右から左へ走査
-	for i := start_pos to 0 by -1 do
-		segment := mid(self, dint_to_uint(m), dint_to_uint(i + 1));
-		if segment = searchString then
-			String_lastIndexOf := i;
-			return;
-		end_if;
-	end_for;
-	String_lastIndexOf := -1;
 	{end}
 end
 

--- a/test/string_lib/test_string_lib.txt
+++ b/test/string_lib/test_string_lib.txt
@@ -816,14 +816,14 @@ TEST_S(test_String_lastIndexOf)
 	EXPECT_EQ_INT32(-1, String_lastIndexOf(self:='hello', searchString:='hellO', position:=4));
 	EXPECT_EQ_INT32(-1, String_lastIndexOf(self:='hello', searchString:='Hello', position:=4));
 	//
-	EXPECT_EQ_INT32(4, String_lastIndexOf(self:='', searchString:='', position:=4));
+	EXPECT_EQ_INT32(0, String_lastIndexOf(self:='', searchString:='', position:=4));
 	EXPECT_EQ_INT32(-1, String_lastIndexOf(self:='', searchString:='a', position:=4));
 	// 2
 	EXPECT_EQ_INT32(2, String_lastIndexOf(self:='hello', searchString:='', position:=2));
 	//
 	EXPECT_EQ_INT32(-1, String_lastIndexOf(self:='hello', searchString:='o', position:=2));
-	EXPECT_EQ_INT32(-1, String_lastIndexOf(self:='hello', searchString:='e', position:=2));
 	EXPECT_EQ_INT32(2, String_lastIndexOf(self:='hello', searchString:='l', position:=2));
+	EXPECT_EQ_INT32(1, String_lastIndexOf(self:='hello', searchString:='e', position:=2));
 	EXPECT_EQ_INT32(0, String_lastIndexOf(self:='hello', searchString:='h', position:=2));
 	EXPECT_EQ_INT32(-1, String_lastIndexOf(self:='hello', searchString:='H', position:=2));
 	//
@@ -837,13 +837,13 @@ TEST_S(test_String_lastIndexOf)
 	EXPECT_EQ_INT32(-1, String_lastIndexOf(self:='hello', searchString:='lO', position:=2));
 	EXPECT_EQ_INT32(-1, String_lastIndexOf(self:='hello', searchString:='Lo', position:=2));
 	//
-	EXPECT_EQ_INT32(-1, String_lastIndexOf(self:='hello', searchString:='llo', position:=2));
+	EXPECT_EQ_INT32(2, String_lastIndexOf(self:='hello', searchString:='llo', position:=2));
 	EXPECT_EQ_INT32(1, String_lastIndexOf(self:='hello', searchString:='ell', position:=2));
 	EXPECT_EQ_INT32(0, String_lastIndexOf(self:='hello', searchString:='hel', position:=2));
 	EXPECT_EQ_INT32(-1, String_lastIndexOf(self:='hello', searchString:='oll', position:=2));
 	EXPECT_EQ_INT32(-1, String_lastIndexOf(self:='hello', searchString:='heL', position:=2));
 	//
-	EXPECT_EQ_INT32(-1, String_lastIndexOf(self:='hello', searchString:='ello', position:=2));
+	EXPECT_EQ_INT32(1, String_lastIndexOf(self:='hello', searchString:='ello', position:=2));
 	EXPECT_EQ_INT32(0, String_lastIndexOf(self:='hello', searchString:='hell', position:=2));
 	EXPECT_EQ_INT32(-1, String_lastIndexOf(self:='hello', searchString:='olle', position:=2));
 	EXPECT_EQ_INT32(-1, String_lastIndexOf(self:='hello', searchString:='helL', position:=2));
@@ -853,7 +853,7 @@ TEST_S(test_String_lastIndexOf)
 	EXPECT_EQ_INT32(-1, String_lastIndexOf(self:='hello', searchString:='hellO', position:=2));
 	EXPECT_EQ_INT32(-1, String_lastIndexOf(self:='hello', searchString:='Hello', position:=2));
 	//
-	EXPECT_EQ_INT32(2, String_lastIndexOf(self:='', searchString:='', position:=2));
+	EXPECT_EQ_INT32(0, String_lastIndexOf(self:='', searchString:='', position:=2));
 	EXPECT_EQ_INT32(-1, String_lastIndexOf(self:='', searchString:='a', position:=2));
 	{end}
 END_TEST_S
@@ -1330,7 +1330,7 @@ TEST_S(test_String_padEnd)
 	EXPECT_EQ_STRING('helloxy', String_padEnd(self:='hello', targetLength:=7, padString:='xy'));
 	EXPECT_EQ_STRING('helloxyx', String_padEnd(self:='hello', targetLength:=8, padString:='xy'));
 	EXPECT_EQ_STRING('helloxyxy', String_padEnd(self:='hello', targetLength:=9, padString:='xy'));
-	EXPECT_EQ_STRING('helloxyxyх', String_padEnd(self:='hello', targetLength:=10, padString:='xy'));
+	EXPECT_EQ_STRING('helloxyxyx', String_padEnd(self:='hello', targetLength:=10, padString:='xy'));
 	EXPECT_EQ_STRING('helloabc', String_padEnd(self:='hello', targetLength:=8, padString:='abc'));
 	EXPECT_EQ_STRING('helloabca', String_padEnd(self:='hello', targetLength:=9, padString:='abc'));
 	EXPECT_EQ_STRING('helloabcab', String_padEnd(self:='hello', targetLength:=10, padString:='abc'));


### PR DESCRIPTION
This pull request updates the implementation and tests for the `String_lastIndexOf` function to handle empty search strings and specific positions more consistently with standard string library behavior. It also corrects a test expectation in the `String_padEnd` tests. The following are the most important changes:

### String_lastIndexOf behavior and tests

* Updated `String_lastIndexOf` in `string_lib.txt` to return the minimum of the given position and the string length when the search string is empty, aligning with typical string library semantics. This also changes the logic for negative positions and empty needles.
* Modified multiple test cases in `test_string_lib.txt` to reflect the new behavior for empty strings and specific positions, ensuring the tests match the updated implementation. [[1]](diffhunk://#diff-a628094333a78a9a4d682fb8ad90575a596b541adec0dec6ac6ceff845a55dc7L819-R826) [[2]](diffhunk://#diff-a628094333a78a9a4d682fb8ad90575a596b541adec0dec6ac6ceff845a55dc7L840-R846) [[3]](diffhunk://#diff-a628094333a78a9a4d682fb8ad90575a596b541adec0dec6ac6ceff845a55dc7L856-R856)

### String_padEnd test correction

* Fixed an incorrect expected value in the `String_padEnd` tests, replacing a non-ASCII character with the correct pad string.

### Build/test instructions

* Updated the example build command in `README.md` to include the `-D_TEST_` flag, ensuring tests are built with the correct configuration.